### PR TITLE
fix(s3): vendor-agnostic endpoint and region for S3-compatible providers

### DIFF
--- a/services/s3_toolkit.py
+++ b/services/s3_toolkit.py
@@ -15,8 +15,8 @@ def parse_s3_url(s3_url):
     # Extract region from the host
     region = parsed_url.hostname.split('.')[1]
     
-    # Construct endpoint URL
-    endpoint_url = f"https://{region}.digitaloceanspaces.com"
+    # Use endpoint from env if defined, else fallback to DO Spaces
+    endpoint_url = os.getenv('S3_ENDPOINT_URL') or f"https://{region}.digitaloceanspaces.com"
     
     return bucket_name, region, endpoint_url
 

--- a/services/s3_toolkit.py
+++ b/services/s3_toolkit.py
@@ -12,11 +12,16 @@ def parse_s3_url(s3_url):
     # Extract bucket name from the host
     bucket_name = parsed_url.hostname.split('.')[0]
     
-    # Extract region from the host
-    region = parsed_url.hostname.split('.')[1]
+    # Use S3_REGION env var if defined, else extract from host, else None
+    region = os.getenv('S3_REGION')
+    if not region:
+        host_parts = parsed_url.hostname.split('.') if parsed_url.hostname else []
+        region = host_parts[1] if len(host_parts) > 1 else None
     
     # Use endpoint from env if defined, else fallback to DO Spaces
-    endpoint_url = os.getenv('S3_ENDPOINT_URL') or f"https://{region}.digitaloceanspaces.com"
+    endpoint_url = os.getenv('S3_ENDPOINT_URL')
+    if not endpoint_url and region:
+        endpoint_url = f"https://{region}.digitaloceanspaces.com"
     
     return bucket_name, region, endpoint_url
 


### PR DESCRIPTION
Esta PR elimina el vendor lock-in de DigitalOcean Spaces en el toolkit S3 y mejora la compatibilidad con otros proveedores S3-compatible.

- Si S3_ENDPOINT_URL está definida, se usa como endpoint para el cliente S3.
- Si no está definida, se sigue usando el endpoint de DigitalOcean Spaces según la región (comportamiento anterior).
- Si S3_REGION está definida, se usa como región para el cliente S3.
- Si no está definida, la región se extrae del hostname como antes.
- No se requieren nuevas variables ni cambios en la firma de funciones.
- Retrocompatible: los usuarios actuales no tienen que modificar nada.

Permite usar MinIO, R2, Supabase, y otros proveedores S3-compatible sin romper la compatibilidad con los entornos existentes.